### PR TITLE
fix(deps): [sc-32782] Fix action to show correct metrics

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
     - run: yarn outdated --json | node ${GITHUB_ACTION_PATH}/calcOutdatedMetrics.js | ${GITHUB_ACTION_PATH}/shipMetrics.sh
       shell: bash {0}
       env:

--- a/calcOutdatedMetrics.js
+++ b/calcOutdatedMetrics.js
@@ -34,15 +34,17 @@ process.stdin.on("end", function () {
 
       packageList?.forEach((package) => {
         const [name, currentVersion, wanted, latestVersion] = package;
-        const [currentMajor, currentMinor, currentPatch] =
-          currentVersion.split(".");
-        const [latestMajor, latestMinor, latestPatch] =
-          latestVersion.split(".");
+        const [currentMajor, currentMinor, currentPatch] = currentVersion
+          .split(".")
+          .map(parseInt);
+        const [latestMajor, latestMinor, latestPatch] = latestVersion
+          .split(".")
+          .map(parseInt);
 
         if (currentMajor >= latestMajor) {
           if (currentMinor >= latestMinor) {
             if (currentPatch >= latestPatch) {
-              throw new Error("package is not outdated");
+              throw new Error(`package is not outdated: ${name}`);
             } else {
               behindPatch.push(package);
             }

--- a/calcOutdatedMetrics.js
+++ b/calcOutdatedMetrics.js
@@ -1,69 +1,78 @@
-process.stdin.resume();
-process.stdin.setEncoding('utf8');
-let data = '';
+const { exec } = require("child_process");
 
-process.stdin.on('data', function (chunk) {
+process.stdin.resume();
+process.stdin.setEncoding("utf8");
+let data = "";
+
+process.stdin.on("data", function (chunk) {
   data += chunk;
 });
 
-process.stdin.on('end', function () {
-  const jsonLines = data.split('\n');
-  const lineWithDependencyTable = jsonLines.find(json =>
-    json.includes('{"type":"table"'),
-  );
+process.stdin.on("end", function () {
+  exec(
+    "cat package.json | jq '.dependencies, .devDependencies | keys | length' | paste -s -d+ - | bc",
+    (err, stdout) => {
+      const jsonLines = data.split("\n");
+      const lineWithDependencyTable = jsonLines.find((json) =>
+        json.includes('{"type":"table"')
+      );
 
-  if (!lineWithDependencyTable) {
-    console.log('data:', data);
-    throw new Error(
-      `Did not receive output from 'yarn outdated'. data: ${data}`,
-    );
-  }
-  const parsedData = JSON.parse(lineWithDependencyTable);
-  const packageList = parsedData.data.body;
-
-  const numberOfPackages = packageList?.length;
-
-  const upToDate = [];
-  const behindPatch = [];
-  const behindMinor = [];
-  const behindMajor = [];
-
-  packageList?.forEach(package => {
-    const [name, currentVersion, wanted, latestVersion] = package;
-    const [currentMajor, currentMinor, currentPatch] = currentVersion.split('.');
-    const [latestMajor, latestMinor, latestPatch] = latestVersion.split('.');
-
-    if (currentMajor >= latestMajor) {
-      if (currentMinor >= latestMinor) {
-        if (currentPatch >= latestPatch) {
-          upToDate.push(package);
-        } else {
-          behindPatch.push(package);
-        }
-      } else {
-        behindMinor.push(package);
+      if (!lineWithDependencyTable) {
+        console.log("data:", data);
+        throw new Error(
+          `Did not receive output from 'yarn outdated'. data: ${data}`
+        );
       }
-    } else {
-      behindMajor.push(package);
+      const parsedData = JSON.parse(lineWithDependencyTable);
+      const packageList = parsedData.data.body;
+
+      const numberOfPackages = parseInt(stdout);
+
+      const behindPatch = [];
+      const behindMinor = [];
+      const behindMajor = [];
+
+      packageList?.forEach((package) => {
+        const [name, currentVersion, wanted, latestVersion] = package;
+        const [currentMajor, currentMinor, currentPatch] =
+          currentVersion.split(".");
+        const [latestMajor, latestMinor, latestPatch] =
+          latestVersion.split(".");
+
+        if (currentMajor >= latestMajor) {
+          if (currentMinor >= latestMinor) {
+            if (currentPatch >= latestPatch) {
+              throw new Error("package is not outdated");
+            } else {
+              behindPatch.push(package);
+            }
+          } else {
+            behindMinor.push(package);
+          }
+        } else {
+          behindMajor.push(package);
+        }
+      });
+
+      const numBehindPatch = behindPatch.length;
+      const numBehindMinor = behindMinor.length;
+      const numBehindMajor = behindMajor.length;
+      const numUpToDate =
+        numberOfPackages - numBehindMajor - numBehindMinor - numBehindPatch;
+
+      const percentUpToDate = (numUpToDate / numberOfPackages).toFixed(2);
+      const percentBehindPatch = (numBehindPatch / numberOfPackages).toFixed(2);
+      const percentBehindMinor = (numBehindMinor / numberOfPackages).toFixed(2);
+      const percentBehindMajor = (numBehindMajor / numberOfPackages).toFixed(2);
+
+      const results = {
+        numberOfPackages,
+        percentUpToDate,
+        percentBehindPatch,
+        percentBehindMinor,
+        percentBehindMajor,
+      };
+      process.stdout.write(JSON.stringify(results, null, 4));
     }
-  });
-
-  const numUpToDate = upToDate.length;
-  const numBehindPatch = behindPatch.length;
-  const numBehindMinor = behindMinor.length;
-  const numBehindMajor = behindMajor.length;
-
-  const percentUpToDate = (numUpToDate / numberOfPackages).toFixed(2);
-  const percentBehindPatch = (numBehindPatch / numberOfPackages).toFixed(2);
-  const percentBehindMinor = (numBehindMinor / numberOfPackages).toFixed(2);
-  const percentBehindMajor = (numBehindMajor / numberOfPackages).toFixed(2);
-
-  const results = {
-    numberOfPackages,
-    percentUpToDate,
-    percentBehindPatch,
-    percentBehindMinor,
-    percentBehindMajor,
-  };
-  process.stdout.write(JSON.stringify(results, null, 4));
+  );
 });

--- a/calcOutdatedMetrics.js
+++ b/calcOutdatedMetrics.js
@@ -1,90 +1,104 @@
 const { exec } = require("child_process");
 
-process.stdin.resume();
-process.stdin.setEncoding("utf8");
+const COUNT_NUM_PACKAGES_CMD =
+  "cat package.json | jq '.dependencies, .devDependencies | keys | length' | paste -s -d+ - | bc";
+
 let data = "";
 
-process.stdin.on("data", function (chunk) {
-  data += chunk;
-});
+(() => {
+  setup();
+  main();
+})();
 
-process.stdin.on("end", function () {
-  exec(
-    "cat package.json | jq '.dependencies, .devDependencies | keys | length' | paste -s -d+ - | bc",
-    (err, stdout) => {
-      const jsonLines = data.split("\n");
-      const lineWithDependencyTable = jsonLines.find((json) =>
-        json.includes('{"type":"table"')
-      );
+function setup() {
+  process.stdin.resume();
+  process.stdin.setEncoding("utf8");
 
-      if (!lineWithDependencyTable) {
-        console.log("data:", data);
-        throw new Error(
-          `Did not receive output from 'yarn outdated'. data: ${data}`
-        );
-      }
-      const parsedData = JSON.parse(lineWithDependencyTable);
-      const packageList = parsedData.data.body;
+  process.stdin.on("data", function (chunk) {
+    data += chunk;
+  });
+}
 
+function main() {
+  process.stdin.on("end", function () {
+    exec(COUNT_NUM_PACKAGES_CMD, (err, stdout) => {
       const numberOfPackages = parseInt(stdout);
-
-      const semverToArr = (semverStr) =>
-        semverStr.split(".").map((str) => parseInt(str));
-
-      const behindPatch = [];
-      const behindMinor = [];
-      const behindMajor = [];
-
-      const sortPackage = (package) => {
-        const [name, currentVersion, wanted, latestVersion] = package;
-
-        // handle forked packages (ex., bell, nslds-parser)
-        if (latestVersion === "exotic") return;
-
-        const [currentMajor, currentMinor, currentPatch] =
-          semverToArr(currentVersion);
-        const [latestMajor, latestMinor, latestPatch] =
-          semverToArr(latestVersion);
-
-        if (currentMajor < latestMajor) {
-          behindMajor.push(package);
-          return;
-        }
-
-        if (currentMinor < latestMinor) {
-          behindMinor.push(package);
-          return;
-        }
-
-        if (currentPatch < latestPatch) {
-          behindPatch.push(package);
-          return;
-        }
-
-        throw new Error(`package is not outdated: ${name}`);
-      };
-
-      packageList?.forEach(sortPackage);
-
-      const numBehindPatch = behindPatch.length;
-      const numBehindMinor = behindMinor.length;
-      const numBehindMajor = behindMajor.length;
-      const numUpToDate =
-        numberOfPackages - numBehindMajor - numBehindMinor - numBehindPatch;
-
-      const percentUpToDate = (numUpToDate / numberOfPackages).toFixed(4);
-      const percentBehindPatch = (numBehindPatch / numberOfPackages).toFixed(4);
-      const percentBehindMinor = (numBehindMinor / numberOfPackages).toFixed(4);
-      const percentBehindMajor = (numBehindMajor / numberOfPackages).toFixed(4);
-
-      const results = {
-        numberOfPackages,
-        percentUpToDate,
-        percentBehindPatch,
-        percentBehindMinor,
-        percentBehindMajor,
-      };
+      const results = calcPercentBehind(data, numberOfPackages);
       process.stdout.write(JSON.stringify(results, null, 4));
+    });
+  });
+}
+
+const semverToArr = (semverStr) =>
+  semverStr.split(".").map((str) => parseInt(str));
+
+const sortPackages = (packageList) => {
+  const behindPatch = [];
+  const behindMinor = [];
+  const behindMajor = [];
+
+  const sortPackage = (package) => {
+    const [name, currentVersion, wanted, latestVersion] = package;
+    // handle forked packages (ex., bell, nslds-parser)
+    if (latestVersion === "exotic") return;
+
+    const [currentMajor, currentMinor, currentPatch] =
+      semverToArr(currentVersion);
+    const [latestMajor, latestMinor, latestPatch] = semverToArr(latestVersion);
+
+    if (currentMajor < latestMajor) {
+      behindMajor.push(package);
+      return;
     }
+    if (currentMinor < latestMinor) {
+      behindMinor.push(package);
+      return;
+    }
+    if (currentPatch < latestPatch) {
+      behindPatch.push(package);
+      return;
+    }
+
+    throw new Error(`package is not outdated: ${name}`);
+  };
+
+  packageList.forEach(sortPackage);
+
+  return { behindPatch, behindMinor, behindMajor };
+};
+
+const calcPercentBehind = (yarnOutdatedOutput, numberOfPackages) => {
+  const jsonLines = yarnOutdatedOutput.split("\n");
+  const lineWithDependencyTable = jsonLines.find((json) =>
+    json.includes('{"type":"table"')
   );
-});
+
+  if (!lineWithDependencyTable) {
+    throw new Error(
+      `Did not receive output from 'yarn outdated'. data: ${yarnOutdatedOutput}`
+    );
+  }
+  const parsedData = JSON.parse(lineWithDependencyTable);
+  const packageList = parsedData.data.body;
+
+  const { behindPatch, behindMinor, behindMajor } = sortPackages(packageList);
+
+  const numBehindPatch = behindPatch.length;
+  const numBehindMinor = behindMinor.length;
+  const numBehindMajor = behindMajor.length;
+  const numUpToDate =
+    numberOfPackages - numBehindMajor - numBehindMinor - numBehindPatch;
+
+  const percentUpToDate = (numUpToDate / numberOfPackages).toFixed(4);
+  const percentBehindPatch = (numBehindPatch / numberOfPackages).toFixed(4);
+  const percentBehindMinor = (numBehindMinor / numberOfPackages).toFixed(4);
+  const percentBehindMajor = (numBehindMajor / numberOfPackages).toFixed(4);
+
+  return {
+    numberOfPackages,
+    percentUpToDate,
+    percentBehindPatch,
+    percentBehindMinor,
+    percentBehindMajor,
+  };
+};

--- a/calcOutdatedMetrics.js
+++ b/calcOutdatedMetrics.js
@@ -60,10 +60,10 @@ process.stdin.on("end", function () {
       const numUpToDate =
         numberOfPackages - numBehindMajor - numBehindMinor - numBehindPatch;
 
-      const percentUpToDate = (numUpToDate / numberOfPackages).toFixed(2);
-      const percentBehindPatch = (numBehindPatch / numberOfPackages).toFixed(2);
-      const percentBehindMinor = (numBehindMinor / numberOfPackages).toFixed(2);
-      const percentBehindMajor = (numBehindMajor / numberOfPackages).toFixed(2);
+      const percentUpToDate = (numUpToDate / numberOfPackages).toFixed(4);
+      const percentBehindPatch = (numBehindPatch / numberOfPackages).toFixed(4);
+      const percentBehindMinor = (numBehindMinor / numberOfPackages).toFixed(4);
+      const percentBehindMajor = (numBehindMajor / numberOfPackages).toFixed(4);
 
       const results = {
         numberOfPackages,

--- a/calcOutdatedMetrics.js
+++ b/calcOutdatedMetrics.js
@@ -30,8 +30,8 @@ process.stdin.on('end', function () {
 
   packageList?.forEach(package => {
     const [name, currentVersion, wanted, latestVersion] = package;
-    const [currentMajor, currentMinor, currentPatch] = currentVersion;
-    const [latestMajor, latestMinor, latestPatch] = latestVersion;
+    const [currentMajor, currentMinor, currentPatch] = currentVersion.split('.');
+    const [latestMajor, latestMinor, latestPatch] = latestVersion.split('.');
 
     if (currentMajor >= latestMajor) {
       if (currentMinor >= latestMinor) {

--- a/calcOutdatedMetrics.js
+++ b/calcOutdatedMetrics.js
@@ -36,10 +36,10 @@ process.stdin.on("end", function () {
         const [name, currentVersion, wanted, latestVersion] = package;
         const [currentMajor, currentMinor, currentPatch] = currentVersion
           .split(".")
-          .map(parseInt);
+          .map((str) => parseInt(str));
         const [latestMajor, latestMinor, latestPatch] = latestVersion
           .split(".")
-          .map(parseInt);
+          .map((str) => parseInt(str));
 
         if (currentMajor >= latestMajor) {
           if (currentMinor >= latestMinor) {


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/summer/story/32782

## What

Fix issues with our shared action to send metrics on % of out-of-date dependencies to datadog.

## Why

Couple of issues here:
- One, this was written with the assumption that `yarn outdated` was listing all dependencies in a project (as per the docs), however the command only lists outdated dependencies. So the total # of deps we were using was wrong.
- We were parsing the semver incorrectly, which also threw everything off.

## How

- Add an additional command to parse the package.json and build the total number of dependencies ourselves
- Add `.split('.')` to the semver string so we can destructure it correctly, and convert strings to numbers so we can compare correctly

Also increased the precision of the percentages -- this should ensure that they add up to 100%, or at least get close enough that we don't see a wavy line at the top of the graph.

This will only work in single-package repos. I made a PR in the monorepo to stop using this action: https://github.com/simplifidev/summer/pull/2078. We'll need a separate solution for the monorepo.

## How to Test

Here's the before and after of the output for each repo:

### shared

**before:**
![Screen Shot 2022-05-03 at 7 10 04 PM](https://user-images.githubusercontent.com/26844435/166587533-4ae6745f-40fc-47c6-9983-f32985d59a73.png)

**after:**
![Screen Shot 2022-05-03 at 7 09 44 PM](https://user-images.githubusercontent.com/26844435/166587549-da69a564-200a-4637-9ee9-9ceaf76219ec.png)

### server

**before:**
![Screen Shot 2022-05-03 at 7 24 18 PM](https://user-images.githubusercontent.com/26844435/166589198-c935920e-0fc7-4681-bf23-ef0f7a247d92.png)

**after:**
![Screen Shot 2022-05-03 at 7 37 08 PM](https://user-images.githubusercontent.com/26844435/166591185-5a134825-bf3a-43ef-80c7-965ebdd66e3b.png)


### devbot

**before:**
![Screen Shot 2022-05-03 at 7 39 04 PM](https://user-images.githubusercontent.com/26844435/166591335-30cf2bd3-c8e3-460f-9a21-3da0574e1e3a.png)


**after:**

![Screen Shot 2022-05-03 at 7 38 13 PM](https://user-images.githubusercontent.com/26844435/166591300-4f780672-eee7-424e-a432-6e090751b510.png)

